### PR TITLE
com_fields category fields change event causing problem in Persian fa-IR

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -345,6 +345,15 @@ class FieldsHelper
 				Joomla.loadingLayer('show');
 				var cat = jQuery(element);
 				if (cat.val() == '" . $assignedCatids . "')return;
+				var elements = document.querySelectorAll('.field-calendar');
+                		for (var i = 0; i < elements.length; i++) {
+				    var calendarfield  = elements[i],
+					instance = calendarfield._joomlaCalendar;
+
+				    if (instance) {
+					instance.setAltValue();
+				    }
+				}
 				jQuery('input[name=task]').val('field.storeform');
 				element.form.action='" . $uri . "';
 				element.form.submit();


### PR DESCRIPTION
Pull Request for Issue #16628 .

### Summary of Changes
Assign to _joomlaCalendar alt value for support Persian dates.


### Testing Instructions
1- make sure you have more than two category for articles(com_content)
2- make sure you have at least a field for articles with context: com_content.article in com_fields
3- change back-end language to Persian(fa-IR).
4- go to Content > Articles. in Persian language the path is: محتوا > مطالب
5- edit an article and change category field value to another one.
6- change category field value


### Expected result
After change category field value you shouldn't see an error: DateTime::__construct(): Failed to parse time string (۱۳۹۶-۰۳-۰۶ ۰۳:۳۶:۰۲) at position 0 (�): Unexpected character in page's title



### Actual result
after change category field value you see an error: DateTime::__construct(): Failed to parse time string (۱۳۹۶-۰۳-۰۶ ۰۳:۳۶:۰۲) at position 0 (�): Unexpected character
Page updated with errors, top controls bar lost, editor not loaded, big part of HTML code lost.
In page header you will see error message:
0 DateTime::__construct(): Failed to parse time string (۱۳۹۶-۰۳-۲۳ ۱۶:۴۸:۰۰) at position 0 (�): Unexpected character


### Documentation Changes Required

